### PR TITLE
Dev v1.3.2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -55,14 +55,14 @@ files = [
 
 [[package]]
 name = "pipe-fp"
-version = "1.1.7"
+version = "2.0.0"
 description = "Functional piping for Python. ➡️"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "pipe_fp-1.1.7-py3-none-any.whl", hash = "sha256:54723acf366ea7a2edda15a19d96a04253d3bcbceeb2c3729738967b1a2d7d1d"},
-    {file = "pipe_fp-1.1.7.tar.gz", hash = "sha256:93def9ab78156a225a90e3b918afddf012648be581f64b4d42d36d6d03b1d5a8"},
+    {file = "pipe_fp-2.0.0-py3-none-any.whl", hash = "sha256:4e1eee653077d6ff442dfc4b7aecf503edb0ba33a199785d7ab3414531e3b2eb"},
+    {file = "pipe_fp-2.0.0.tar.gz", hash = "sha256:d635517352022d5601af88db4b51059b1cfa5f7cb3cbaaae508c4a38a8dca45b"},
 ]
 
 [[package]]
@@ -150,4 +150,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "a0d6e84f3cc2f33303b91f238ed46a209ee674d9685fdc89f37512f3779ad222"
+content-hash = "0591379b2266833aa1ebe27a566674437d74a2f86c363c56c501de851e4fa6dc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "curry-fp"
-version = "1.3.1"
+version = "1.3.2"
 description = "Functional currying in Python. 🥘"
 license = "MIT"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 requires-python = ">=3.9"
 dynamic = [ "classifiers" ]
 dependencies = [
-    "pipe-fp (>=1.1.5,<2.0.0)"
+    "pipe-fp (>=2.0.0,<3.0.0)"
 ]
 
 [tool.poetry]

--- a/src/curry_fp/__init__.py
+++ b/src/curry_fp/__init__.py
@@ -1,1 +1,1 @@
-from .curry import curry
+from .curry import curry as curry

--- a/src/curry_fp/curry.py
+++ b/src/curry_fp/curry.py
@@ -47,7 +47,7 @@ def curry(f: Union[Callable, partial]):
         def is_base_case(f: partial):
             return count_co_args_kwargs(f.func.__code__) == count_partial_args(f)
 
-        return pipe(
+        return pipe[Callable](
             lambda f: partial(f, *args, **kwargs),
             lambda f: apply_defaults(f) if ... in args else f,
             lambda f: f() if is_base_case(f) else curry(f)

--- a/src/curry_fp/curry.py
+++ b/src/curry_fp/curry.py
@@ -16,7 +16,7 @@ def curry(f: Union[Callable, partial]):
     .. code-block:: python
         @curry
         def sum_all(a: int, b: int=2, c: int=3) -> int:
-            return a + b + c       
+            return a + b + c
 
     **Without using default values**
     >>> sum_all(1)(2)(3)
@@ -29,7 +29,7 @@ def curry(f: Union[Callable, partial]):
 
     def count_partial_args(f: partial):
         return len(f.args) + len(f.keywords)
-    
+
     def count_co_args_kwargs(co: CodeType):
         return co.co_argcount + co.co_kwonlyargcount
 
@@ -52,7 +52,7 @@ def curry(f: Union[Callable, partial]):
         return pipe[Callable](
             lambda f: partial(f, *args, **kwargs),
             lambda f: apply_defaults(f) if ... in args else f,
-            lambda f: f() if is_base_case(f) else curry(f)
+            lambda f: f() if is_base_case(f) else curry(f),
         )(f)
 
     return wrapper

--- a/src/curry_fp/curry.py
+++ b/src/curry_fp/curry.py
@@ -1,7 +1,9 @@
+from collections.abc import Callable
 from functools import partial
 from inspect import BoundArguments, signature
-from typing import Callable, Union, Any
 from types import CodeType
+from typing import Any, Union
+
 from pipe_fp import pipe
 
 

--- a/test/test_curry.py
+++ b/test/test_curry.py
@@ -25,7 +25,7 @@ def test_curry():
     assert sum_all(1)(2)(...) == 6
     assert sum_all(1)(...)(2) == 6
     assert sum_all(...)(1)(2) == 6
-    
+
     assert sum_all(1, 2)(...) == 6
     assert sum_all(...)(1, 2) == 6
 


### PR DESCRIPTION
## What's New?
### Updates
- Updated dependency `pipe-fp` to `v2.0.0`.

### Fixes
- Fixed an issue with the `curry` function not being explicitly re-exported.
- Switched from deprecated `typing.Callable` to `collections.abc.Callable`.